### PR TITLE
Index events in state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/awfm9/flow-dps
 go 1.16
 
 require (
+	github.com/OneOfOne/xxhash v1.2.5
 	github.com/dgraph-io/badger/v2 v2.2007.2
 	github.com/fxamacker/cbor v1.5.1
 	github.com/klauspost/compress v1.12.2

--- a/mapper/chain.go
+++ b/mapper/chain.go
@@ -20,6 +20,6 @@ import (
 
 type Chain interface {
 	Active() (uint64, flow.Identifier, flow.StateCommitment)
-	Events() []flow.Event
+	Events() ([]flow.Event, error)
 	Forward() error
 }

--- a/mapper/chain.go
+++ b/mapper/chain.go
@@ -20,5 +20,6 @@ import (
 
 type Chain interface {
 	Active() (uint64, flow.Identifier, flow.StateCommitment)
+	Events() []flow.Event
 	Forward() error
 }

--- a/mapper/indexer.go
+++ b/mapper/indexer.go
@@ -21,5 +21,5 @@ import (
 )
 
 type Indexer interface {
-	Index(height uint64, blockID flow.Identifier, commit flow.StateCommitment, deltas []model.Delta) error
+	Index(height uint64, blockID flow.Identifier, commit flow.StateCommitment, deltas []model.Delta, events []flow.Event) error
 }

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -24,16 +24,14 @@ import (
 
 	"github.com/rs/zerolog"
 
-	"github.com/awfm9/flow-dps/model"
-
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/flattener"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/trie"
 	"github.com/onflow/flow-go/ledger/complete/wal"
+
+	"github.com/awfm9/flow-dps/model"
 )
 
-// Static is a random access ledger that bootstraps the index from a static
-// snapshot of the protocol state and the corresponding ledger write-ahead log.
 type Mapper struct {
 	log     zerolog.Logger
 	chain   Chain
@@ -153,8 +151,12 @@ First:
 				break Second
 			}
 
-			events := m.chain.Events()
-			err := m.indexer.Index(height, blockID, commit, m.deltas, events)
+			events, err := m.chain.Events()
+			if err != nil {
+				return fmt.Errorf("could not index events: %w (height: %d, block: %x, commit: %x)", err, height, blockID, commit)
+			}
+
+			err = m.indexer.Index(height, blockID, commit, m.deltas, events)
 			if err != nil {
 				return fmt.Errorf("could not index deltas: %w (height: %d, block: %x, commit: %x)", err, height, blockID, commit)
 			}

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -22,8 +22,9 @@ import (
 	"os"
 	"sync"
 
-	"github.com/awfm9/flow-dps/model"
 	"github.com/rs/zerolog"
+
+	"github.com/awfm9/flow-dps/model"
 
 	"github.com/onflow/flow-go/ledger/common/pathfinder"
 	"github.com/onflow/flow-go/ledger/complete/mtrie/flattener"
@@ -151,7 +152,9 @@ First:
 			if !bytes.Equal(hash, commit) {
 				break Second
 			}
-			err := m.indexer.Index(height, blockID, commit, m.deltas)
+
+			events := m.chain.Events()
+			err := m.indexer.Index(height, blockID, commit, m.deltas, events)
 			if err != nil {
 				return fmt.Errorf("could not index deltas: %w (height: %d, block: %x, commit: %x)", err, height, blockID, commit)
 			}

--- a/model/prefixes.go
+++ b/model/prefixes.go
@@ -20,4 +20,5 @@ const (
 	PrefixBlockIndex  = 3
 	PrefixCommitIndex = 4
 	PrefixDeltaIndex  = 5
+	PrefixEventIndex  = 6
 )

--- a/state/core.go
+++ b/state/core.go
@@ -267,7 +267,7 @@ func (c *Core) Height(commit flow.StateCommitment) (uint64, error) {
 	return height, nil
 }
 
-func (c *Core) Events(height uint64, types ...[]byte) ([]flow.Event, error) {
+func (c *Core) Events(height uint64, types ...string) ([]flow.Event, error) {
 	// Make sure that the request is for a height below the currently active
 	// sentinel height; otherwise, we haven't indexed yet and we might return
 	// false information.
@@ -303,7 +303,8 @@ func (c *Core) Events(height uint64, types ...[]byte) ([]flow.Event, error) {
 			if len(types) != 0 {
 				var include bool
 				for _, t := range types {
-					if bytes.Equal(typeHash, t) {
+					tHash := xxhash.New64().Sum([]byte(t))
+					if bytes.Equal(typeHash, tHash) {
 						include = true
 						break
 					}


### PR DESCRIPTION
## Goal of this PR

Fixes #16 

This PR:

* Makes the chain store the events for the current block height in its properties
* Adds a `Events` method to the chain which returns all flow events for the current block height
* Makes the `Mapper` retrieve those events and pass them along to `core.Index`
* The events are then indexed with a key that is formatted like such:

| **Length (bytes)** | `1`               | `8`          | `64`                        |
|:-------------------|:------------------|:-------------|:----------------------------|
| **Type**           | uint              | uint64       | hex string                  |
| **Description**    | Index type prefix | Block Height | Transaction Type (xxHashed) |
| **Example Value**  | `6`               | `425`        | `45D66Q565F5DEDB[...]`      |

This format contains the block height before the transaction type in order to make it possible to get all events for a given block height regardless of the event type.

* The events can then be retrieved through a method on `Core` called `Events` which takes a block height, and optionally one or more types (as unhashed strings). 