### PR TITLE
Update feeder tests to match with new implementation

### DIFF
--- a/service/feeder/ledger_wal_test.go
+++ b/service/feeder/ledger_wal_test.go
@@ -1,10 +1,8 @@
 package feeder_test
 
 import (
-	"encoding/hex"
 	"testing"
 
-	"github.com/onflow/flow-go/model/flow"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -12,42 +10,18 @@ import (
 )
 
 func TestFeeder_Delta(t *testing.T) {
-	const (
-		firstCommit = "d85b7dc2d6be69c5cc10f0d128595352354e57fbd923ac1ad3f734518610ca73"
-		secondCommit = "20a7c8d5447a9acc9cb8de372935669f50645ebd106d98e71a25cf5196595856"
-	)
-
 	f, err := feeder.FromLedgerWAL("./testdata")
 	require.NoError(t, err)
 
-	// Verify that trying to feed an invalid commit does not work.
-	deltas, err := f.Delta(flow.StateCommitment(`invalid_commit`))
-	assert.Error(t, err)
-	assert.Empty(t, deltas)
-
-	// First state commitment hash after the root hash in test data.
-	commit, err := hex.DecodeString(firstCommit)
-	require.NoError(t, err)
-
-	// Verify that calling feed on a commit that has deltas and in the right order returns no error and a slice of deltas.
-	deltas, err = f.Delta(commit)
+	deltas1, err := f.Delta([]byte{})
 	assert.NoError(t, err)
-	assert.NotEmpty(t, deltas)
+	assert.NotEmpty(t, deltas1)
 
-	// Next state commitment hash after the root hash in test data.
-	commit, err = hex.DecodeString(secondCommit)
-	require.NoError(t, err)
-
-	// Verify that multiple subsequent calls to Feed() work as expected.
-	deltas, err = f.Delta(commit)
+	// Verify that multiple subsequent calls to Delta() work as expected.
+	deltas2, err := f.Delta([]byte{})
 	assert.NoError(t, err)
-	assert.NotEmpty(t, deltas)
+	assert.NotEmpty(t, deltas2)
 
-	// Trying to feed the first commit again should fail.
-	commit, err = hex.DecodeString(firstCommit)
-	require.NoError(t, err)
-
-	deltas, err = f.Delta(commit)
-	assert.Error(t, err)
-	assert.Empty(t, deltas)
+	// Verify that both calls returned different deltas.
+	assert.NotEqual(t, deltas1, deltas2)
 }


### PR DESCRIPTION
## Goal of this PR

This PR fixes the feeder unit tests which got broken because the feeder no longer takes the given commit hash into account. It now only returns the deltas for the next hash, regardless of its input.

## How to test it

Make sure the logic makes sense and that the tests are passing on the CI.