### PR TITLE
Indexing: fix execution fork handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not initialize chain")
 		}
-		feeder, err := feeder.FromLedgerWAL(flagTrie)
+		feeder, err := feeder.FromLedgerWAL(log, flagTrie)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not initialize feeder")
 		}

--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not initialize chain")
 		}
-		feeder, err := feeder.FromLedgerWAL(log, flagTrie)
+		feeder, err := feeder.FromLedgerWAL(flagTrie)
 		if err != nil {
 			log.Fatal().Err(err).Msg("could not initialize feeder")
 		}

--- a/service/feeder/ledger_wal.go
+++ b/service/feeder/ledger_wal.go
@@ -71,9 +71,9 @@ func (l *LedgerWAL) Delta(commit flow.StateCommitment) (dps.Delta, error) {
 	// that case, we should just return it, because it means the mapper is
 	// rewinding and switching to another branch, because the one it was one
 	// didn't continue.
-	deltas, ok := l.cache[string(commit)]
-	if ok && deltas.Len() > 0 {
-		return deltas.PopBack().(dps.Delta), nil
+	forks, ok := l.cache[string(commit)]
+	if ok && forks.Len() > 0 {
+		return forks.PopBack().(dps.Delta), nil
 	}
 
 	// Otherwise, we read from the on-disk file until we find a delta that can
@@ -125,12 +125,12 @@ func (l *LedgerWAL) Delta(commit flow.StateCommitment) (dps.Delta, error) {
 			delta = append(delta, change)
 		}
 		if !bytes.Equal(update.RootHash, commit) {
-			deltas, ok := l.cache[string(update.RootHash)]
+			forks, ok := l.cache[string(update.RootHash)]
 			if !ok {
-				deltas = deque.New(10, 10)
-				l.cache[string(update.RootHash)] = deltas
+				forks = deque.New(10, 10)
+				l.cache[string(update.RootHash)] = forks
 			}
-			deltas.PushBack(delta)
+			forks.PushBack(delta)
 			l.log.Debug().Hex("commit", update.RootHash).Msg("added non-sequential delta to cache")
 			continue
 		}

--- a/service/feeder/ledger_wal.go
+++ b/service/feeder/ledger_wal.go
@@ -73,7 +73,9 @@ func (l *LedgerWAL) Delta(commit flow.StateCommitment) (dps.Delta, error) {
 	// didn't continue.
 	forks, ok := l.cache[string(commit)]
 	if ok && forks.Len() > 0 {
-		return forks.PopBack().(dps.Delta), nil
+		delta := forks.PopBack().(dps.Delta)
+		l.log.Debug().Hex("commit", commit).Int("num_changes", len(delta)).Msg("returning non-sequential delta from cache")
+		return delta, nil
 	}
 
 	// Otherwise, we read from the on-disk file until we find a delta that can
@@ -131,7 +133,7 @@ func (l *LedgerWAL) Delta(commit flow.StateCommitment) (dps.Delta, error) {
 				l.cache[string(update.RootHash)] = forks
 			}
 			forks.PushBack(delta)
-			l.log.Debug().Hex("commit", update.RootHash).Msg("added non-sequential delta to cache")
+			l.log.Debug().Hex("commit", update.RootHash).Int("num_changes", len(delta)).Msg("added non-sequential delta to cache")
 			continue
 		}
 

--- a/service/feeder/ledger_wal.go
+++ b/service/feeder/ledger_wal.go
@@ -63,6 +63,13 @@ func FromLedgerWAL(dir string) (*LedgerWAL, error) {
 	return &l, nil
 }
 
+func (l *LedgerWAL) Clear() {
+	for key := range l.cache {
+		delete(l.cache, key)
+	}
+	l.cache = make(map[string]*deque.Deque)
+}
+
 func (l *LedgerWAL) Delta(commit flow.StateCommitment) (dps.Delta, error) {
 
 	// If we have a cached delta for the commit, it means that we skipped it at
@@ -73,9 +80,6 @@ func (l *LedgerWAL) Delta(commit flow.StateCommitment) (dps.Delta, error) {
 	forks, ok := l.cache[string(commit)]
 	if ok && forks.Len() > 0 {
 		delta := forks.PopBack().(dps.Delta)
-		if forks.Len() == 0 {
-			delete(l.cache, string(commit))
-		}
 		return delta, nil
 	}
 

--- a/service/feeder/ledger_wal.go
+++ b/service/feeder/ledger_wal.go
@@ -57,7 +57,7 @@ func FromLedgerWAL(dir string) (*LedgerWAL, error) {
 	l := LedgerWAL{
 		reader:    pwal.NewReader(segments),
 		cache:     make(map[string]*deque.Deque),
-		threshold: 100,
+		threshold: 300,
 	}
 
 	return &l, nil

--- a/service/feeder/ledger_wal_test.go
+++ b/service/feeder/ledger_wal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/onflow/flow-go/model/flow"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,11 +14,11 @@ import (
 
 func TestFeeder_Delta(t *testing.T) {
 	const (
-		firstCommit = "d85b7dc2d6be69c5cc10f0d128595352354e57fbd923ac1ad3f734518610ca73"
+		firstCommit  = "d85b7dc2d6be69c5cc10f0d128595352354e57fbd923ac1ad3f734518610ca73"
 		secondCommit = "20a7c8d5447a9acc9cb8de372935669f50645ebd106d98e71a25cf5196595856"
 	)
 
-	f, err := feeder.FromLedgerWAL("./testdata")
+	f, err := feeder.FromLedgerWAL(zerolog.Nop(), "./testdata")
 	require.NoError(t, err)
 
 	// Verify that trying to feed an invalid commit does not work.

--- a/service/feeder/ledger_wal_test.go
+++ b/service/feeder/ledger_wal_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/onflow/flow-go/model/flow"
-	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +17,7 @@ func TestFeeder_Delta(t *testing.T) {
 		secondCommit = "20a7c8d5447a9acc9cb8de372935669f50645ebd106d98e71a25cf5196595856"
 	)
 
-	f, err := feeder.FromLedgerWAL(zerolog.Nop(), "./testdata")
+	f, err := feeder.FromLedgerWAL("./testdata")
 	require.NoError(t, err)
 
 	// Verify that trying to feed an invalid commit does not work.

--- a/service/mapper/feeder.go
+++ b/service/mapper/feeder.go
@@ -21,5 +21,6 @@ import (
 )
 
 type Feeder interface {
+	Clear()
 	Delta(commit flow.StateCommitment) (dps.Delta, error)
 }

--- a/service/mapper/mapper.go
+++ b/service/mapper/mapper.go
@@ -241,6 +241,10 @@ Outer:
 				return fmt.Errorf("could not index last: %w", err)
 			}
 
+			// Clear the feeder cache, which knows nothing about when we reach
+			// a finalized block.
+			m.feed.Clear()
+
 			log.Info().Msg("block indexed")
 
 			m.tree = tree

--- a/service/mapper/mapper.go
+++ b/service/mapper/mapper.go
@@ -267,7 +267,7 @@ Outer:
 
 		delta, err := m.feed.Delta(commitTree)
 		if len(deltas) == 0 && errors.Is(err, dps.ErrNotFound) {
-			return fmt.Errorf("could not resolve fork, aborting")
+			return fmt.Errorf("could not resolve gap, aborting")
 		}
 		if errors.Is(err, dps.ErrNotFound) {
 			log.Warn().Msg("delta retrieval failed, rewinding")

--- a/service/mapper/mapper.go
+++ b/service/mapper/mapper.go
@@ -165,7 +165,6 @@ Outer:
 
 		commitTree := tree.RootHash()
 		var log zerolog.Logger
-
 	Inner:
 		for {
 


### PR DESCRIPTION
When encountering an execution fork, it can happen that the feeder returns a series of deltas that don't lead the state trie to the next finalized block's state commitment. This PR stores a references to the state trie at the last indexed block and introduces a limit for the feeder, at which it considers the requested delta as not found.

When the mapper encounters a not found error, it will reset the state trie to the last indexed state trie, and restart on a new path from there. This will basically switch the indexing to a new fork. When it encounters the error without any cached deltas, it means that no fork is available at the last indexed state trie anymore, and we weren't able to find a path from the last indexed state commitment to the state commitment of the next finalized block.

As the feeder knows nothing about how many forks there are, it knows nothing about how much it should cache. Execution nodes keep 1000 state tries in memory, which means we can have a fork up to 1000 deltas in the past. However, this applies to every path alternative in case of forks, so we might well need to keep more than 1000 at times.

We solve this by bailing if 1000 deltas in a row had to be cached (the desired one wasn't found), but allowing the cache to grow beyond that between different requests. The mapper then explicitly clears the cache of the feeder when it indexes a new finalized block, because any forks cached before that become orphaned and irrelevant at that point.