### PR TITLE
Storage: fix key encoding for `ledger.Path`

### DIFF
--- a/models/dps/state.go
+++ b/models/dps/state.go
@@ -40,7 +40,7 @@ type Index interface {
 
 type Chain interface {
 	Header(height uint64) (*flow.Header, error)
-	Events(height uint64, types ...string) ([]flow.Event, error)
+	Events(height uint64, types ...flow.EventType) ([]flow.Event, error)
 }
 
 type Last interface {

--- a/service/state/chain.go
+++ b/service/state/chain.go
@@ -32,7 +32,7 @@ func (c *Chain) Header(height uint64) (*flow.Header, error) {
 	return &header, err
 }
 
-func (c *Chain) Events(height uint64, types ...string) ([]flow.Event, error) {
+func (c *Chain) Events(height uint64, types ...flow.EventType) ([]flow.Event, error) {
 	// Make sure that the request is for a height below the currently active
 	// sentinel height; otherwise, we haven't indexed yet and we might return
 	// false information.

--- a/service/state/height.go
+++ b/service/state/height.go
@@ -26,7 +26,7 @@ type Height struct {
 
 func (h *Height) ForBlock(blockID flow.Identifier) (uint64, error) {
 	var height uint64
-	err := h.core.db.View(storage.RetrieveHeightByBlock(blockID[:], &height))
+	err := h.core.db.View(storage.RetrieveHeightByBlock(blockID, &height))
 	return height, err
 }
 

--- a/service/storage/encoding.go
+++ b/service/storage/encoding.go
@@ -18,6 +18,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/onflow/flow-go/ledger"
 	"github.com/onflow/flow-go/model/flow"
 )
 
@@ -32,6 +33,8 @@ func encodeKey(prefix uint8, segments ...interface{}) []byte {
 		case []byte:
 			val = s
 		case flow.Identifier:
+			val = s[:]
+		case ledger.Path:
 			val = s[:]
 		default:
 			panic(fmt.Sprintf("unknown type (%T)", segment))

--- a/service/storage/encoding.go
+++ b/service/storage/encoding.go
@@ -16,61 +16,28 @@ package storage
 
 import (
 	"encoding/binary"
+	"fmt"
+
+	"github.com/onflow/flow-go/model/flow"
 )
 
 func encodeKey(prefix uint8, segments ...interface{}) []byte {
 	key := []byte{prefix}
-	var it int
+	var val []byte
 	for _, segment := range segments {
 		switch s := segment.(type) {
 		case uint64:
-			val := make([]byte, 8)
-
+			val = make([]byte, 8)
 			binary.BigEndian.PutUint64(val, s)
-			key = append(key, val...)
-			it += 8
 		case []byte:
-			val := make([]byte, len(s))
-
-			copy(val, s)
-			key = append(key, val...)
-			it += len(s)
+			val = s
+		case flow.Identifier:
+			val = s[:]
 		default:
-			panic("unknown type")
+			panic(fmt.Sprintf("unknown type (%T)", segment))
 		}
+		key = append(key, val...)
 	}
 
 	return key
 }
-
-// func decodeKey(key []byte, segments ...interface{}) (prefix uint8, err error) {
-// 	var it int
-
-// 	if len(key) > 0 {
-// 		prefix = key[0]
-// 		it++
-// 	}
-// 	for _, segment := range segments {
-// 		switch ptr := segment.(type) {
-// 		case *uint64:
-// 			*ptr = binary.BigEndian.Uint64(key[it : it+8])
-// 			it += 8
-// 		case *[]byte:
-// 			length := len(*ptr)
-// 			if length == 0 { // This makes it possible to skip a pin by just giving nil.
-// 				continue
-// 			}
-
-// 			// Retrieve value.
-// 			val := make([]byte, length)
-// 			copy(val, key[it:it+length])
-
-// 			*ptr = val
-// 			it += length
-// 		default:
-// 			return prefix, fmt.Errorf("unknown segment type %T", ptr)
-// 		}
-// 	}
-
-// 	return prefix, nil
-// }

--- a/service/storage/encoding.go
+++ b/service/storage/encoding.go
@@ -35,7 +35,7 @@ func encodeKey(prefix uint8, segments ...interface{}) []byte {
 		case flow.Identifier:
 			val = s[:]
 		case ledger.Path:
-			val = s[:]
+			val = []byte(s)
 		default:
 			panic(fmt.Sprintf("unknown type (%T)", segment))
 		}

--- a/service/storage/operations.go
+++ b/service/storage/operations.go
@@ -215,7 +215,7 @@ func retrieve(key []byte, value interface{}) func(tx *badger.Txn) error {
 			return nil
 		})
 		if err != nil {
-			return fmt.Errorf("unable to retrieve zalue: %w", err)
+			return fmt.Errorf("unable to retrieve value: %w", err)
 		}
 
 		return nil

--- a/service/storage/operations.go
+++ b/service/storage/operations.go
@@ -77,11 +77,11 @@ func RetrieveHeightByBlock(blockID flow.Identifier, height *uint64) func(*badger
 }
 
 func RetrieveCommitByHeight(height uint64, commit *flow.StateCommitment) func(*badger.Txn) error {
-	return retrieve(encodeKey(prefixIndexHeightToCommit, height), &commit)
+	return retrieve(encodeKey(prefixIndexHeightToCommit, height), commit)
 }
 
 func RetrieveHeader(height uint64, header *flow.Header) func(*badger.Txn) error {
-	return retrieve(encodeKey(prefixDataHeader, height), &header)
+	return retrieve(encodeKey(prefixDataHeader, height), header)
 }
 
 func RetrieveEvents(height uint64, types []flow.EventType, events *[]flow.Event) func(*badger.Txn) error {


### PR DESCRIPTION
This PR fixes a crash from the fact that there is no explicit encoding path for a key that contains a `ledger.Path`. I would rather avoid having to manually cast it every time and have the underlying logic handle that for us.

I was a bit confused that `flow.StateCommitment` didn't need this, but I found out that this is a type alias (`type flow.StateCommitment = []byte`), rather than a type definition (`type ledger.Path []byte`). Note the missing equal sign in the second one.

I also came across some other small inconsistencies that I fixed. For instance, we should either only use primitive types for the interfacing, or use the native Flow types; we mixed a bit of both. I decided to use the Flow types consistently. Also, there were to retrieval functions that passed a double pointer to the `retrieve` function, which made an unnecessary double indirection.